### PR TITLE
[Jitera] Create/Update models and migrations

### DIFF
--- a/migrations/1719100352828-update-reports-table.js
+++ b/migrations/1719100352828-update-reports-table.js
@@ -1,0 +1,49 @@
+const { MigrationInterface, QueryRunner } = require("typeorm");
+
+module.exports = class updateReportsTable1719100352828 {
+    name = 'updateReportsTable1719100352828'
+
+    async up(queryRunner) {
+        await queryRunner.query(`ALTER TABLE "reports" ADD "encrypted_password" character varying(255)`);
+        await queryRunner.query(`ALTER TABLE "reports" ADD "email" character varying(255)`);
+        await queryRunner.query(`ALTER TABLE "reports" ADD "reset_password_token" character varying(255)`);
+        await queryRunner.query(`ALTER TABLE "reports" ADD "reset_password_sent_at" TIMESTAMP`);
+        await queryRunner.query(`ALTER TABLE "reports" ADD "remember_created_at" TIMESTAMP`);
+        await queryRunner.query(`ALTER TABLE "reports" ADD "current_sign_in_at" TIMESTAMP`);
+        await queryRunner.query(`ALTER TABLE "reports" ADD "last_sign_in_at" TIMESTAMP`);
+        await queryRunner.query(`ALTER TABLE "reports" ADD "current_sign_in_ip" character varying(255)`);
+        await queryRunner.query(`ALTER TABLE "reports" ADD "last_sign_in_ip" character varying(255)`);
+        await queryRunner.query(`ALTER TABLE "reports" ADD "sign_in_count" integer CHECK (sign_in_count >= 0)`);
+        await queryRunner.query(`ALTER TABLE "reports" ADD "password" character varying(255)`);
+        await queryRunner.query(`ALTER TABLE "reports" ADD "password_confirmation" character varying(255)`);
+        await queryRunner.query(`ALTER TABLE "reports" ADD "locked_at" TIMESTAMP`);
+        await queryRunner.query(`ALTER TABLE "reports" ADD "failed_attempts" integer CHECK (failed_attempts >= 0)`);
+        await queryRunner.query(`ALTER TABLE "reports" ADD "unlock_token" character varying(255)`);
+        await queryRunner.query(`ALTER TABLE "reports" ADD "confirmation_token" character varying(255)`);
+        await queryRunner.query(`ALTER TABLE "reports" ADD "unconfirmed_email" character varying(255)`);
+        await queryRunner.query(`ALTER TABLE "reports" ADD "confirmed_at" TIMESTAMP`);
+        await queryRunner.query(`ALTER TABLE "reports" ADD "confirmation_sent_at" TIMESTAMP`);
+    }
+
+    async down(queryRunner) {
+        await queryRunner.query(`ALTER TABLE "reports" DROP COLUMN "encrypted_password"`);
+        await queryRunner.query(`ALTER TABLE "reports" DROP COLUMN "email"`);
+        await queryRunner.query(`ALTER TABLE "reports" DROP COLUMN "reset_password_token"`);
+        await queryRunner.query(`ALTER TABLE "reports" DROP COLUMN "reset_password_sent_at"`);
+        await queryRunner.query(`ALTER TABLE "reports" DROP COLUMN "remember_created_at"`);
+        await queryRunner.query(`ALTER TABLE "reports" DROP COLUMN "current_sign_in_at"`);
+        await queryRunner.query(`ALTER TABLE "reports" DROP COLUMN "last_sign_in_at"`);
+        await queryRunner.query(`ALTER TABLE "reports" DROP COLUMN "current_sign_in_ip"`);
+        await queryRunner.query(`ALTER TABLE "reports" DROP COLUMN "last_sign_in_ip"`);
+        await queryRunner.query(`ALTER TABLE "reports" DROP COLUMN "sign_in_count"`);
+        await queryRunner.query(`ALTER TABLE "reports" DROP COLUMN "password"`);
+        await queryRunner.query(`ALTER TABLE "reports" DROP COLUMN "password_confirmation"`);
+        await queryRunner.query(`ALTER TABLE "reports" DROP COLUMN "locked_at"`);
+        await queryRunner.query(`ALTER TABLE "reports" DROP COLUMN "failed_attempts"`);
+        await queryRunner.query(`ALTER TABLE "reports" DROP COLUMN "unlock_token"`);
+        await queryRunner.query(`ALTER TABLE "reports" DROP COLUMN "confirmation_token"`);
+        await queryRunner.query(`ALTER TABLE "reports" DROP COLUMN "unconfirmed_email"`);
+        await queryRunner.query(`ALTER TABLE "reports" DROP COLUMN "confirmed_at"`);
+        await queryRunner.query(`ALTER TABLE "reports" DROP COLUMN "confirmation_sent_at"`);
+    }
+}

--- a/src/reports/report.entity.ts
+++ b/src/reports/report.entity.ts
@@ -30,6 +30,27 @@ export class Report {
   @Column()
   mileage: number;
 
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  encrypted_password: string;
+
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  email: string;
+
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  reset_password_token: string;
+
+  @Column({ type: 'timestamp', nullable: true })
+  reset_password_sent_at: Date;
+
+  @Column({ type: 'timestamp', nullable: true })
+  remember_created_at: Date;
+
+  @Column({ type: 'timestamp', nullable: true })
+  current_sign_in_at: Date;
+
+  @Column({ type: 'timestamp', nullable: true })
+  last_sign_in_at: Date;
+
   @ManyToOne(() => User, (user) => user.reports) // 1st arg to solve circular dependency
   user: User;
 }


### PR DESCRIPTION
This pull request is created by **JITERA**
# Description

#### [ERD] Changes
| table | guideline | type | columns |
| --- | --- | --- | --- |
| reports | This file already exists. Update the Report entity to include new columns with appropriate types and validation options. For example, add the following properties to the class:
- approved: boolean
- price: number
- maker: string
- model: string
- year: number
- lat: number
- lng: number
- mileage: number
- encrypted_password: string (optional, max length 255)
- email: string (optional, max length 255)
- reset_password_token: string (optional, max length 255)
- reset_password_sent_at: Date (optional)
- remember_created_at: Date (optional)
- current_sign_in_at: Date (optional)
- last_sign_in_at: Date (optional)
- current_sign_in_ip: string (optional, max length 255)
- last_sign_in_ip: string (optional, max length 255)
- sign_in_count: number (optional, numerical validation as specified)
- password: string (optional, max length 255)
- password_confirmation: string (optional, max length 255)
- locked_at: Date (optional)
- failed_attempts: number (optional, numerical validation as specified)
- unlock_token: string (optional, max length 255)
- confirmation_token: string (optional, max length 255)
- unconfirmed_email: string (optional, max length 255)
- confirmed_at: Date (optional)
- confirmation_sent_at: Date (optional)
Ensure to use the appropriate decorators for type and validation, such as @Column, @IsOptional, @Length, @IsNumber, etc., according to the ORM being used. | UPDATED | id: integer, approved: boolean, price: float, maker: varchar, model: varchar, year: integer, lat: float, lng: float, mileage: integer, encrypted_password: varchar, email: varchar, reset_password_token: varchar, reset_password_sent_at: date, remember_created_at: date, current_sign_in_at: date, last_sign_in_at: date, current_sign_in_ip: varchar, last_sign_in_ip: varchar, sign_in_count: integer, password: varchar, password_confirmation: varchar, locked_at: date, failed_attempts: integer, unlock_token: varchar, confirmation_token: varchar, unconfirmed_email: varchar, confirmed_at: date, confirmation_sent_at: date |
------